### PR TITLE
Remove unused dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.0|^7.0",
         "psr/log": "^1.0|^2.0|^3.0",
-        "webeweb/core-library": "^8.23",
         "webeweb/geo-json-library": "^1.3"
     },
     "require-dev": {


### PR DESCRIPTION
I tried to install your library but it requires `ext-ftp` due to the requirement of `webeweb/core-library`.

Fortunately, it looks like this dependency is not used and can ba safely removed! :ok_hand: 